### PR TITLE
add rocky mirror description & make it official

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -136,7 +136,10 @@ repos:
     official: true
 
   - name: Rockylinux
-    official: false
+    help: |
+      Since we are officially listed, our mirror will be automatically selected if it fits best to your location
+    additional: https://mirrors.rockylinux.org/mirrormanager/mirrors
+    official: true
 
   - name: Arch Linux Debug
     help: |


### PR DESCRIPTION
I was able to get us listed as an official mirror for rockylinux again by adding proper categories to our host,
see https://mirrors.rockylinux.org/mirrormanager/mirrors
