### PR TITLE
fix: endeavouros mirror is official now

### DIFF
--- a/repos.yaml
+++ b/repos.yaml
@@ -197,5 +197,5 @@ repos:
       pacman -Syy
       ```
     additional: https://www.archlinux.org/mirrors/adfinis-on-exoscale.ch/
-    official: false
+    official: true
     localName: endeavouros


### PR DESCRIPTION
We're now on the official mirrorlist.

See: https://github.com/endeavouros-team/PKGBUILDS/commit/9a53d9bd581a7d4d65c6c50ebf8fffc65b9788a6